### PR TITLE
Fixed P2P_discovery sockets not being released on stop

### DIFF
--- a/defnet/p2p_discovery.lua
+++ b/defnet/p2p_discovery.lua
@@ -67,7 +67,7 @@ function M.create(port)
 					coroutine.yield()
 				end
 			end
-			udp_broadcast:close()
+			broadcaster:close()
 			broadcast_co = nil
 		end)
 		return coroutine.resume(broadcast_co)
@@ -103,6 +103,7 @@ function M.create(port)
 				end
 				coroutine.yield()
 			end
+			listener:close()
 			listen_co = nil
 		end)
 		return coroutine.resume(listen_co)


### PR DESCRIPTION
Hello. There's a problem with p2p_discovery.lua in that, when `.stop` gets called on an active listener, the socket is never closed. This blocks `.listen` from working a second time.

Similarly, line 70 attempts `udp_broadcast:close()` but `udp_broadcast` isn't defined.